### PR TITLE
Update marshalling library to point to NilFoundation org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -21,4 +21,4 @@
 	url = git@github.com:nilfoundation/codec.git
 [submodule "libs/marshalling"]
 	path = libs/marshalling
-	url = git@github.com:nemothenoone/marshalling.git
+	url = git@github.com:nilfoundation/marshalling.git


### PR DESCRIPTION
Currently libs/marshalling submodule is pointing to git@github.com:nemothenoone/marshalling.git, which is not an open repo. In this diff I'm re-pointing it to NilFoundation org, to make it fetchable during the build phase of DBMS.

The diff is under an umbrella of
https://github.com/NilFoundation/dbms/issues/12, where I'm trying to get things building with GitHub Actions.